### PR TITLE
add setBasketHandling() to Ili2dbReplace task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 group 'ch.so.agi'
-version '1.0.2-SNAPSHOT'
-version env('GRETL_VERSION', '1.0.2-SNAPSHOT')
+version '1.0.4-SNAPSHOT'
+version env('GRETL_VERSION', '1.0.4-SNAPSHOT')
 
 repositories {
     mavenCentral()

--- a/src/main/java/ch/so/agi/gretl/tasks/Ili2pgReplace.java
+++ b/src/main/java/ch/so/agi/gretl/tasks/Ili2pgReplace.java
@@ -11,7 +11,7 @@ import org.gradle.api.tasks.TaskAction;
 
 public class Ili2pgReplace extends Ili2pgAbstractTask {
     @InputFile 
-    public File dataFile=null;
+    public Object dataFile=null;
     @TaskAction
     public void replaceData()
     {

--- a/src/main/java/ch/so/agi/gretl/tasks/Ili2pgReplace.java
+++ b/src/main/java/ch/so/agi/gretl/tasks/Ili2pgReplace.java
@@ -1,6 +1,5 @@
 package ch.so.agi.gretl.tasks;
 
-
 import ch.ehi.ili2db.base.Ili2db;
 import ch.ehi.ili2db.gui.Config;
 import ch.so.agi.gretl.tasks.impl.Ili2pgAbstractTask;
@@ -10,25 +9,26 @@ import java.io.File;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 
-
 public class Ili2pgReplace extends Ili2pgAbstractTask {
-	@InputFile 
-	public File dataFile=null;
+    @InputFile 
+    public File dataFile=null;
     @TaskAction
     public void replaceData()
     {
         Config settings=createConfig();
-    	int function=Config.FC_REPLACE;
+        int function=Config.FC_REPLACE;
         if (dataFile==null) {
             return;
         }
+        
         String xtfFilename=this.getProject().file(dataFile).getPath();
-		if(Ili2db.isItfFilename(xtfFilename)){
-			settings.setItfTransferfile(true);
-		}
-		settings.setXtffile(xtfFilename);
-    	run(function, settings);
+        if(Ili2db.isItfFilename(xtfFilename)){
+            settings.setItfTransferfile(true);
+        }
+        settings.setXtffile(xtfFilename);
+        
+        settings.setBasketHandling(settings.BASKET_HANDLING_READWRITE);
+        run(function, settings);
     }
-
 }
 


### PR DESCRIPTION
Ili2dbReplace worked for an initial import. Subsequent imports failed:

`Info: Basket SO_Nutzungsplanung_20170915.Rechtsvorschriften(oid SO_Nutzungsplanung_20170915.Rechtsvorschriften)...
Info: SO_Nutzungsplanung_20170915.Rechtsvorschriften.Dokument read ids...
Info: SO_Nutzungsplanung_20170915.Rechtsvorschriften.HinweisWeitereDokumente read ids...
failed to query arp_npl.rechtsvorschrften_hinweisweiteredokumente
Error: failed to query arp_npl.rechtsvorschrften_hinweisweiteredokumente
Error:   ERROR: column r0.t_ili_tid does not exist
  Position: 17
failed to run ili2pg
java.lang.IllegalStateException: failed to check if table arp_npl.rechtsvorschrften_plandokument exists
        at ch.ehi.sqlgen.DbUtility.pgTableExists(DbUtility.java:134)`

Adding `setBasketHandling()` to the `Ili2dbReplace` task solves this issue.
