### PR TITLE
centralized dependency definition to dependencies.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,15 @@ version '1.0.4'+System.getProperty('release','-SNAPSHOT')
 version env('GRETL_VERSION', "$project.version")
 
 ext {
-    //dependencies
-    junitVersion = '4.12'
-    postgresqlVersion = '42.1.4'
-    ioxIliVersion = '1.20.+' // use SNAPSHOT
-    ilivalidatorVersion = '1.6.+' // use SNAPSHOT
-    ili2pgVersion = '3.11.+' // use SNAPSHOT
-    ioxWkfVersion = '0.+' // use SNAPSHOT
+    //dependency versions
     sqliteJdbcVersion = '3.8.11.2'
     derbyVersion = '10.13.1.1'
     jenkinsClientVersion = '0.3.7'
+
+    // dependencies
+    sqliteJdbcDependency = [group: 'org.xerial', name: 'sqlite-jdbc', version: sqliteJdbcVersion]
+    derbyDependency = [group: 'org.apache.derby', name: 'derby', version: derbyVersion]
+    jenkinsClientDependency = 'com.offbytwo.jenkins:jenkins-client:' + jenkinsClientVersion
 }
 
 repositories {
@@ -26,8 +25,9 @@ repositories {
     }
 }
 
-apply plugin: 'java'
+apply from: 'dependencies.gradle'
 
+apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
@@ -38,32 +38,32 @@ sourceSets {
 
 configurations.all {
     resolutionStrategy {
-        force group: 'ch.interlis', name: 'iox-ili', version: ioxIliVersion
+        force ioxIliDependency
     }
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: junitVersion
+    testCompile junitDependency
 
-    compile group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
+    compile postgresqlDependency
 
-    compile group: 'ch.interlis', name: 'ilivalidator', version: ilivalidatorVersion
-    compile group: 'ch.interlis', name: 'ili2pg', version: ili2pgVersion
-    compile group: 'ch.interlis', name: 'iox-wkf', version: ioxWkfVersion
-    compile group: 'ch.interlis', name: 'iox-ili', version: ioxIliVersion
+    compile ilivalidatorDependency
+    compile ili2pgDependency
+    compile ioxWkfDependency
+    compile ioxIliDependency
 
-    compile group: 'org.xerial', name: 'sqlite-jdbc', version: sqliteJdbcVersion
-    compile group: 'org.apache.derby', name: 'derby', version: derbyVersion
+    compile sqliteJdbcDependency
+    compile derbyDependency
 
     // Additional driver possibilities when the need arises:
     // - oracle jdbc driver
     // - sqlserver jdbc driver (Microsoft)
     compile gradleApi()
 
-    testIntegrationCompile group: 'junit', name: 'junit', version: junitVersion
+    testIntegrationCompile junitDependency
 
-    testSystemCompile group: 'junit', name: 'junit', version: junitVersion
-    testSystemCompile 'com.offbytwo.jenkins:jenkins-client:' + jenkinsClientVersion
+    testSystemCompile junitDependency
+    testSystemCompile jenkinsClientDependency
 }
 
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,19 @@
+ext {
+    //dependency versions
+    ioxIliVersion = '1.20.+' // use SNAPSHOT
+    ilivalidatorVersion = '1.6.+' // use SNAPSHOT
+    ili2pgVersion = '3.11.+' // use SNAPSHOT
+    ioxWkfVersion = '0.+' // use SNAPSHOT
+
+    postgresqlVersion = '42.1.4'
+    junitVersion = '4.12'
+
+    // dependencies
+    ioxIliDependency = [ group: 'ch.interlis', name: 'iox-ili', version: ioxIliVersion ]
+    ilivalidatorDependency = [ group: 'ch.interlis', name: 'ilivalidator', version: ilivalidatorVersion ]
+    ili2pgDependency = [ group: 'ch.interlis', name: 'ili2pg', version: ili2pgVersion ]
+    ioxWkfDependency = [ group: 'ch.interlis', name: 'iox-wkf', version: ioxWkfVersion ]
+
+    postgresqlDependency = [ group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion ]
+    junitDependency = [ group: 'junit', name: 'junit', version: junitVersion ]
+}

--- a/docker/build-gretl.sh
+++ b/docker/build-gretl.sh
@@ -7,6 +7,7 @@ echo "https://github.com/keeganwitt/docker-gradle/blob/master/"
 echo "                                  jdk8-alpine/Dockerfile"
 echo "=============================================================="
 
+# TODO no version lock
 cp ../build/libs/gretl-1.0.4-SNAPSHOT.jar gretl
 
 docker build --no-cache --force-rm -t gretl-runtime -f gretl/Dockerfile gretl

--- a/docker/gretl/Dockerfile
+++ b/docker/gretl/Dockerfile
@@ -9,5 +9,7 @@ COPY gretl-1.0.4-SNAPSHOT.jar /home/gradle/libs
 RUN gradle copyToLibs
 RUN ls -la libs
 
+RUN rm /home/gradle/build.gradle
+
 ENTRYPOINT ["gradle", "--offline", "--init-script", "/home/gradle/init.gradle"]
 CMD ["showRepos"]

--- a/docker/gretl/init.gradle
+++ b/docker/gretl/init.gradle
@@ -8,11 +8,7 @@ allprojects {
         }
 
         dependencies {
-            classpath group: 'ch.so.agi', name: 'gretl', version: '1.0.4-SNAPSHOT'
-            classpath group: 'ch.ehi', name: 'ehibasics', version: '1.1.0'
-
-            classpath group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
+            classpath fileTree(dir: '/home/gradle/libs', include: '*.jar')
         }
     }
-    // apply plugin:'java'
 }

--- a/docker/start-gretl.sh
+++ b/docker/start-gretl.sh
@@ -25,4 +25,4 @@ echo "======================================================="
 docker run -i --rm \
     -v "$job_directory":/home/gradle/project \
     -w /home/gradle/project \
-    gretl-runtime "$task_name" "${task_parameter[@]}"
+    gretl-runtime "$task_name" "${task_parameter[@]}" --stacktrace

--- a/inttest/build.gradle
+++ b/inttest/build.gradle
@@ -1,14 +1,30 @@
-group 'ch.so.agi'
-version '1.0.1-SNAPSHOT'
+buildscript {
 
-apply plugin: 'java'
+    apply from: '../dependencies.gradle'
 
-sourceCompatibility = 1.8
+    ext {
+        //dependency versions
+        ehibasicsVersion = '1.1.0'
 
-repositories {
-    mavenCentral()
-}
+        // dependencies
+        ehibasicsDependency = [ group: 'ch.ehi', name: 'ehibasics', version: ehibasicsVersion ]
+    }
 
-dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    repositories {
+        maven {
+            url "http://jars.interlis.ch"
+        }
+        maven {
+            url "http://download.osgeo.org/webdav/geotools/"
+        }
+        mavenCentral()
+    }
+
+    dependencies {
+        // TODO no version lock
+        classpath files('../build/libs/gretl-1.0.4-SNAPSHOT.jar')
+
+        classpath ilivalidatorDependency
+        classpath ehibasicsDependency
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'gretl'
-include 'inttest'


### PR DESCRIPTION
Extracted dependency definition to have one single source of truth for lib versions.

The file *dependencies.gradle* is included into the build.gradle files such that the dependency definitions are available.