### PR TITLE
Fetchsize fix

### DIFF
--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -316,6 +316,8 @@ sourceDb | Datenbank aus der gelesen werden soll
 targetDb | Datenbank in die geschrieben werden soll
 transferSets  | Eine Liste von ``TransferSet``s.
 sqlParameters | Eine Map mit Paaren von Parameter-Name und Parameter-Wert.
+batchSize | Anzahl der Records, die pro Batch in die Ziel-Datenbank geschrieben werden (Standard: 5000). Für sehr grosse Tabellen muss ein kleinerer Wert gewählt werden.
+fetchSize | Anzahl der Records, die auf einmal vom Datenbank-Cursor von der Quell-Datenbank zurückgeliefert werden (Standard: 5000). Für sehr grosse Tabellen muss ein kleinerer Wert gewählt werden.
 
 Eine ``TransferSet`` ist 
 

--- a/gretl/inttest/jobs/db2dbTaskFetchSize/build.gradle
+++ b/gretl/inttest/jobs/db2dbTaskFetchSize/build.gradle
@@ -1,0 +1,20 @@
+import ch.so.agi.gretl.tasks.*
+import ch.so.agi.gretl.api.*
+apply plugin: 'ch.so.agi.gretl'
+
+def GRETLTEST_DBURI = 'gretltest_dburi'
+def db_uri = findProperty(GRETLTEST_DBURI) != null ? findProperty(GRETLTEST_DBURI) : 'jdbc:postgresql://localhost:5432/gretl'
+
+def db_user = "dmluser"
+def db_pass = "dmluser"
+
+defaultTasks 'fetchSizeTask'
+
+task fetchSizeTask(type: Db2Db) {
+    sourceDb =  [db_uri, db_user, db_pass]
+    targetDb = [db_uri, db_user, db_pass]
+    fetchSize = 10
+    transferSets = [
+            new TransferSet('sql/fetchSize.sql', 'db2dbtaskfetchsize.target_data', true)
+    ];
+}

--- a/gretl/inttest/jobs/db2dbTaskFetchSize/sql/fetchSize.sql
+++ b/gretl/inttest/jobs/db2dbTaskFetchSize/sql/fetchSize.sql
@@ -1,0 +1,12 @@
+SELECT
+    t_id, 
+    aint, 
+    adec, 
+    atext, 
+    adate, 
+    atimestamp, 
+    aboolean, 
+    geom_so
+FROM 
+    db2dbtaskfetchsize.source_data
+;

--- a/gretl/src/main/java/ch/so/agi/gretl/steps/Db2DbStep.java
+++ b/gretl/src/main/java/ch/so/agi/gretl/steps/Db2DbStep.java
@@ -25,9 +25,11 @@ public class Db2DbStep {
 
     public static final String PREFIX = "ch.so.agi.gretl.steps.Db2DbStep";
     public static final String SETTING_BATCH_SIZE = PREFIX+".batchSize";
+    public static final String SETTING_FETCH_SIZE = PREFIX+".fetchSize";
     private static GretlLogger log = LogEnvironment.getLogger(Db2DbStep.class);
     private String taskName;
     private int batchSize=5000;
+    private int fetchSize=5000;
 
 
     public Db2DbStep() {
@@ -67,6 +69,19 @@ public class Db2DbStep {
                 
             }
         }
+        
+        String fetchSizeStr=settings.getValue(SETTING_FETCH_SIZE);
+        if(fetchSizeStr!=null) {
+            try {
+                int newFetchSize=Integer.parseInt(fetchSizeStr);
+                if(newFetchSize>=0) { // fetchSize 0 -> fetch all at once
+                    fetchSize=newFetchSize;
+                }
+            }catch(NumberFormatException e) {
+                
+            }
+        }
+        
         log.lifecycle(String.format("Start Db2DbStep(Name: %s SourceDb: %s TargetDb: %s Transfers: %s)", taskName, sourceDb, targetDb, transferSets));
 
         Connection sourceDbConnection = null;
@@ -208,6 +223,7 @@ public class Db2DbStep {
      */
     private ResultSet createResultSet(Connection srcCon, String sqlSelectStatement) throws SQLException {
         Statement SQLStatement = srcCon.createStatement();
+        SQLStatement.setFetchSize(fetchSize);
         ResultSet rs = SQLStatement.executeQuery(sqlSelectStatement);
 
         return rs;

--- a/gretl/src/main/java/ch/so/agi/gretl/tasks/Db2Db.java
+++ b/gretl/src/main/java/ch/so/agi/gretl/tasks/Db2Db.java
@@ -40,6 +40,9 @@ public class Db2Db extends DefaultTask {
     public Integer batchSize=null;
     @Input
     @Optional
+    public Integer fetchSize=null;
+    @Input
+    @Optional
     public java.util.Map<String,String> sqlParameters=null;
 
     @TaskAction
@@ -52,6 +55,9 @@ public class Db2Db extends DefaultTask {
         Settings settings=new Settings();
         if(batchSize!=null) {
             settings.setValue(Db2DbStep.SETTING_BATCH_SIZE, batchSize.toString());
+        }
+        if(fetchSize!=null) {
+            settings.setValue(Db2DbStep.SETTING_FETCH_SIZE, fetchSize.toString());
         }
         try {
             Db2DbStep step = new Db2DbStep(taskName);


### PR DESCRIPTION
Siehe #104.

Neben der batchSize() braucht es ebenfalls auf der Lesen-Seite ("SELECT") etwas Speicherfreundliches damit grosse Tabellen mit dem Db2Db-Task kopiert werden können.

[https://jdbc.postgresql.org/documentation/head/query.html](https://jdbc.postgresql.org/documentation/head/query.html)

Das Problem kann man plausibilisieren, wenn man eine Log-Message beim Schreiben der Daten in die Ziel-DB (=executeBatch()) ausgibt. Bis die erste solche Message geschrieben wird, dauert es relativ lange für grosse Tabellen. Dh. die ganze Tabelle wird zuerst gelesen. Mit stmt.setFetchSize(int) kann man schubweise lesen. Geprüft mit Höhenkurven des Kantons. Interessanterweise war eine kleine Fetchsize (100) und ein sehr kleine Batchsize (10) schneller als grosse Fetch- resp. Batsizes (1000).

Ein Test dazu habe ich geschrieben. Und kurz geprüft, ob er auch was testet. Wenn bewusst eine falsche Vergleichs-Anzahl an Zeilen angeben wird, versagt der Test. Ebenfalls wenn anstelle "fetchSize" als Parameter im Task "fetchSizeaaaa" geschrieben wird.

Das eigentliche "out-of-memory" Problem einfach/sinnvoll zu testen, entzieht sich meiner Kenntnis (ohne gleich die Höhenkurven zu verwenden).
