### PR TITLE
Add 3rd-party plugin to docker image. Remove offline mode (unfortunat…

### DIFF
--- a/runtimeImage/gretl/build.gradle
+++ b/runtimeImage/gretl/build.gradle
@@ -9,6 +9,9 @@ repositories {
         url "http://download.osgeo.org/webdav/geotools/"
     }
     mavenCentral()
+    maven {
+        url "https://plugins.gradle.org/m2/"
+    }
 }
 
 apply plugin: 'java'
@@ -32,6 +35,8 @@ dependencies {
     compile sqliteJdbcDependency
     compile derbyDependency
     compile group: 'ch.ehi', name: 'ehisqlgen', version: '1.13.3'
+    
+    compile "de.undercouch:gradle-download-task:3.4.1"
 }
 
 task copyToLibs(type: Copy) {

--- a/runtimeImage/gretl/gretl
+++ b/runtimeImage/gretl/gretl
@@ -9,4 +9,3 @@ fi
 gradle "${run_parameter[@]}" \
        --init-script /home/gradle/init.gradle \
        --stacktrace \
-       --offline


### PR DESCRIPTION
…ely).

Fremdplugins müssen beim Docker-Image brennen ebenfalls reinkopiert werden. Scheint als "compile"-Abhängigkeit im `runtimeImage/gretl/build.gradle` zu funktionieren. Ebenfalls muss leider der Offlinemodus beim `gradle`-Befehl im Docker-Image entfernt werden, sonst wird überhaupt nicht mit der Aussenwelt gesprochen (dh. auch keine Geodaten von irgendwo heruntergeladen). Öffnet leider somit wieder die Möglichkeit, dass ein Anwender im eigenen build.gradle weitere Bibliotheken, Plugins etc. anwendet, die nicht im Docker-Image sind. 